### PR TITLE
Fix the platform discovery and expose protocol independent ID

### DIFF
--- a/handlers/ocfHandler.js
+++ b/handlers/ocfHandler.js
@@ -84,11 +84,6 @@ var routes = function(req, res) {
     }
 
     function onPlatformFound(platformInfo) {
-        // Do not add platform to the list, if we have already seen it.
-        for (index in discoveredPlatforms) {
-             if (platformInfo.id === discoveredPlatforms[index].pi)
-                 return;
-        }
         var platform = OIC.parsePlatform(platformInfo);
         discoveredPlatforms.push(platform);
     }

--- a/oic/oic.js
+++ b/oic/oic.js
@@ -55,6 +55,9 @@ exports.parseDevice = function(device) {
   if (typeof device.dataModels != "undefined")
     o.dmv = device.dataModels;
 
+  if (typeof device.piid != "undefined")
+    o.piid = device.piid;
+
   console.log(JSON.stringify(o));
 
   return o;


### PR DESCRIPTION
This PR includes the following two changes:

1.  ocfHandler: Fix the platform discovery
2. oic: Expose protocol independent ID of the device

More about piid in the spec: A unique and immutable Device identifier. A Client can detect that a single Device supports multiple communication protocols if it discovers that the Device uses a single Protocol Independent ID value for all the protocols it supports.

